### PR TITLE
Fix Pants omission of default deploy jar excludes.

### DIFF
--- a/repro/BUILD
+++ b/repro/BUILD
@@ -11,7 +11,7 @@ scala_sources(
         # Error: Could not find or load main class repro.Main
         # Caused by: java.lang.ClassNotFoundException: repro.Main
         
-        # "//:google-cloud-pubsub"
+        "//:google-cloud-pubsub"
     ]
 )
 
@@ -21,4 +21,10 @@ deploy_jar(
         ":repro",
     ],
     main = "repro.Main",
+    exclude_files = [
+        r"^META-INF/.*\.SF$",
+        r"^META-INF/.*\.DSA$",
+        r"^META-INF/.*\.RSA$",
+        r"^META-INF/.*\.EC$",
+    ]
 )


### PR DESCRIPTION
Any signing files found in `META-INF/` in jars that compose into a deploy
jar must be skipped but are not by default by Pants. Work around this.

See "The META-INF directory" section here:
https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html

Note that Pants v1 got this right:
https://github.com/pantsbuild/pants/blob/release_1.30.4/src/python/pants/backend/jvm/targets/jvm_binary.py#L136-L202